### PR TITLE
13 Add logic for game over on hitting idiot

### DIFF
--- a/scenes/projectile.tscn
+++ b/scenes/projectile.tscn
@@ -27,6 +27,8 @@ radius = 50.04
 
 [node name="Projectile" type="RigidBody2D"]
 gravity_scale = 0.0
+contact_monitor = true
+max_contacts_reported = 1
 script = ExtResource("1_d3cd1")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
@@ -37,3 +39,5 @@ frame_progress = 0.00269623
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_3b7u6")
 one_way_collision_margin = 0.0
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/scripts/mobs/mob_bat.gd
+++ b/scripts/mobs/mob_bat.gd
@@ -48,3 +48,19 @@ func _ready() -> void:
 func _physics_process(delta: float) -> void:
 	# Move the NPC to the right at 'speed' pixels per second
 	position.x += movement_speed * delta
+
+# Collision detection logic.
+# Only handles collisions with the idiot. Will need to be updated later to handle sheild collision.
+func _on_body_entered(body: Node) -> void:
+	if body is CharacterBody2D:
+		# Both the sheild and the idiot are CharachterBody2D.
+		# This makes it so the game over only happens for idiot hits.
+		if body.name == "Idiot_hero":
+			# Game over. Just goes to the main menu for now.
+			get_tree().change_scene_to_file("res://scenes/menu/main_menu.tscn")
+			# queue_free would remove the projectile if needed.
+			# I don't THINK we need this, since a hit is instant death. But if we
+			# decided against that later maybe with a powerup or something, it's here lol.
+			#queue_free()
+
+	pass # Replace with function body.


### PR DESCRIPTION
- Gives projectiles logic such that if they hit the idiot, game over. (Does not actually game over, just goes back to the main menu for now since there's no game over screen).
- Hitting idiot is based on the name of the CharachterBody2D element "Idiot_hero". Can be expanded to include different actions for shield hit by using same if block.