### PR TITLE
Add super basic parry mechanic

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -47,6 +47,11 @@ Pause={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
+parry={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(187, 9),"global_position":Vector2(196, 55),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="PackedScene" uid="uid://dk41cisdtdonq" path="res://scenes/idiot_hero.tscn" id="2_jn0l8"]
 [ext_resource type="PackedScene" uid="uid://bumwv0mx5w6aq" path="res://scenes/shield.tscn" id="2_w3671"]
 [ext_resource type="PackedScene" uid="uid://cn3lii7exa78k" path="res://scenes/background.tscn" id="3_3s816"]
-[ext_resource type="PackedScene" uid="uid://0mjc0it86aq2" path="res://scenes/mob_bat.tscn" id="4_q6ttw"]
+[ext_resource type="PackedScene" path="res://scenes/mob_bat.tscn" id="4_q6ttw"]
 
 [sub_resource type="GDScript" id="GDScript_81rl6"]
 script/source = "extends Node2D

--- a/scenes/mob_bat.tscn
+++ b/scenes/mob_bat.tscn
@@ -1,7 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://0mjc0it86aq2"]
+[gd_scene load_steps=7 format=3 uid="uid://d3qggqh0seri8"]
 
 [ext_resource type="Script" path="res://scripts/mobs/mob_bat.gd" id="1_5ymdd"]
-[ext_resource type="PackedScene" uid="uid://c70twk71mo8vl" path="res://scenes/projectile.tscn" id="2_3rjrx"]
+[ext_resource type="PackedScene" uid="uid://dmxf6gcphgjg5" path="res://scenes/projectile.tscn" id="2_3rjrx"]
 [ext_resource type="Texture2D" uid="uid://bn7cuqlpvwfru" path="res://assets/sprites/placeholder_bat_flap_1.png" id="2_ei3x0"]
 [ext_resource type="Texture2D" uid="uid://be6apdufjv4cr" path="res://assets/sprites/placeholder_bat_flap_2.png" id="3_l05oc"]
 

--- a/scenes/projectile.tscn
+++ b/scenes/projectile.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://c70twk71mo8vl"]
+[gd_scene load_steps=7 format=3 uid="uid://dmxf6gcphgjg5"]
 
 [ext_resource type="Script" path="res://scripts/mobs/mob_bat.gd" id="1_d3cd1"]
 [ext_resource type="Texture2D" uid="uid://dkft7ngvvftf7" path="res://assets/sprites/projectile_1.png" id="2_tkcaq"]

--- a/scenes/shield.tscn
+++ b/scenes/shield.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://bumwv0mx5w6aq"]
+[gd_scene load_steps=6 format=3 uid="uid://bumwv0mx5w6aq"]
 
 [ext_resource type="Texture2D" uid="uid://dtumenqgkxig" path="res://assets/sprites/bad shield.webp" id="1_1ilqa"]
 [ext_resource type="Script" path="res://scripts/shield/shield_health.gd" id="1_xflaf"]
@@ -6,26 +6,33 @@
 [sub_resource type="CircleShape2D" id="CircleShape2D_3sjvr"]
 radius = 115.0
 
+[sub_resource type="CircleShape2D" id="CircleShape2D_4icvd"]
+radius = 400.005
+
 [sub_resource type="CircleShape2D" id="CircleShape2D_ey6sh"]
 radius = 141.089
 
 [node name="Shield" type="CharacterBody2D"]
 z_index = 10
-position = Vector2(6, 0)
 script = ExtResource("1_xflaf")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(-2, -1)
 scale = Vector2(0.313477, 0.300293)
 texture = ExtResource("1_1ilqa")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="Physical CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_3sjvr")
 
-[node name="Area2D" type="Area2D" parent="."]
+[node name="ParryArea" type="Area2D" parent="."]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-position = Vector2(-4, 3)
+[node name="ParryZoneCollision" type="CollisionShape2D" parent="ParryArea"]
+shape = SubResource("CircleShape2D_4icvd")
+
+[node name="DamageArea" type="Area2D" parent="."]
+
+[node name="DamageZoneCollision" type="CollisionShape2D" parent="DamageArea"]
 shape = SubResource("CircleShape2D_ey6sh")
 
-[connection signal="body_entered" from="Area2D" to="." method="_on_area_2d_body_entered"]
+[connection signal="body_entered" from="ParryArea" to="." method="_on_parry_area_body_entered"]
+[connection signal="body_exited" from="ParryArea" to="." method="_on_parry_area_body_exited"]
+[connection signal="body_entered" from="DamageArea" to="." method="_on_area_2d_body_entered"]

--- a/scripts/mobs/mob_bat.gd
+++ b/scripts/mobs/mob_bat.gd
@@ -36,7 +36,6 @@ func _on_tick():
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	global_tick.timeout.connect(_on_tick)
-	pass # Replace with function body.
 
 # Not required, we're using physics process instead.
 ## Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -62,5 +61,3 @@ func _on_body_entered(body: Node) -> void:
 			# I don't THINK we need this, since a hit is instant death. But if we
 			# decided against that later maybe with a powerup or something, it's here lol.
 			#queue_free()
-
-	pass # Replace with function body.


### PR DESCRIPTION
- Adds parry zone. An area that projectiles can be reflected in prior to taking damage.
- Adds parry on left click. Projectiles in range are reflected when left clicking.
- Adds speed to reflected projectiles. because it's fun. Will replace with something fancier later.

To test:

Launch game, move Shield in front of projectile, left click before projectile enters damage zone. I made the parry zone pretty big for testing, should be easy.